### PR TITLE
Eliminate `any` Type Usage

### DIFF
--- a/libs/core/src/lib/validation-context.ts
+++ b/libs/core/src/lib/validation-context.ts
@@ -45,7 +45,6 @@ export function createValidationContext<T>(model: T, parentPropertyName?: string
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isValidationContext<T>(value: any): value is ValidationContext<T> {
-  return value != null && 'failures' in value && 'modelToValidate' in value;
+export function isValidationContext<T>(value: unknown): value is ValidationContext<T> {
+  return value != null && typeof value === 'object' && 'failures' in value && 'modelToValidate' in value;
 }

--- a/libs/core/src/lib/validation-context.ts
+++ b/libs/core/src/lib/validation-context.ts
@@ -46,5 +46,5 @@ export function createValidationContext<T>(model: T, parentPropertyName?: string
 }
 
 export function isValidationContext<T>(value: unknown): value is ValidationContext<T> {
-  return value != null && typeof value === 'object' && 'failures' in value && 'modelToValidate' in value;
+  return value != null && typeof value === 'object' && !Array.isArray(value) && 'failures' in value && 'modelToValidate' in value;
 }


### PR DESCRIPTION
This pull request includes a small improvement to the `isValidationContext` function in `libs/core/src/lib/validation-context.ts`. The change enhances type safety by replacing the `any` type with `unknown` and adding a check to ensure the value is an object.